### PR TITLE
Implemented refresh token endpoint for spotify authentication

### DIFF
--- a/src/main/java/com/spotifyapp/backend/controller/AuthController.java
+++ b/src/main/java/com/spotifyapp/backend/controller/AuthController.java
@@ -19,4 +19,9 @@ public class AuthController {
     public ResponseEntity<?> authenticateWithSpotify(@RequestParam("code") String code) {
         return ResponseEntity.ok(spotifyAuthService.exchangeCodeForTokens(code));
     }
+
+    @PostMapping("/auth/spotify/refresh")
+    public ResponseEntity<?> refreshSpotifyToken(@RequestParam("refresh_token") String refreshToken) {
+        return ResponseEntity.ok(spotifyAuthService.refreshAccessToken(refreshToken));
+    }
 }

--- a/src/main/java/com/spotifyapp/backend/service/SpotifyAuthService.java
+++ b/src/main/java/com/spotifyapp/backend/service/SpotifyAuthService.java
@@ -51,5 +51,31 @@ public class SpotifyAuthService {
                 new ParameterizedTypeReference<Map<String, Object>>() {}
         );
         return response.getBody();
-}
+    }
+
+    public Map<String, Object> refreshAccessToken(String refreshToken) {
+        String authUrl = "https://accounts.spotify.com/api/token";
+        // Headers
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        String basicAuth = Base64.getEncoder()
+            .encodeToString((clientId + ":" + clientSecret).getBytes());
+        headers.set("Authorization", "Basic " + basicAuth);
+
+        // Body
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "refresh_token");
+        body.add("refresh_token", refreshToken);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                authUrl,
+                HttpMethod.POST,
+                request,
+                new ParameterizedTypeReference<Map<String, Object>>() {}
+        );
+        return response.getBody();
+    }
 }


### PR DESCRIPTION
Added a POST /auth/spotify/refresh endpoint to handle access token renewal using the refresh_token.