### PR TITLE
Basic OAuth flow: Token exchange and H2 storage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'com.h2database:h2'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/spotifyapp/backend/config/SecurityConfig.java
+++ b/src/main/java/com/spotifyapp/backend/config/SecurityConfig.java
@@ -7,13 +7,15 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
-
 public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
+                .headers(headers -> headers
+                        .frameOptions(frame -> frame.sameOrigin()) // 👈 Esto permite ver la consola de H2
+                )
                 .authorizeHttpRequests(auth -> auth
                         .anyRequest().permitAll()
                 );

--- a/src/main/java/com/spotifyapp/backend/controller/AuthController.java
+++ b/src/main/java/com/spotifyapp/backend/controller/AuthController.java
@@ -1,8 +1,15 @@
 package com.spotifyapp.backend.controller;
 
 import com.spotifyapp.backend.service.SpotifyAuthService;
+import com.spotifyapp.backend.service.SpotifyTokenService;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api")
@@ -10,14 +17,38 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final SpotifyAuthService spotifyAuthService;
+    private final SpotifyTokenService spotifyTokenService;
 
-    public AuthController(SpotifyAuthService spotifyAuthService) {
+    public AuthController(SpotifyAuthService spotifyAuthService, SpotifyTokenService spotifyTokenService) {
         this.spotifyAuthService = spotifyAuthService;
+        this.spotifyTokenService = spotifyTokenService;
     }
 
     @PostMapping("/auth/spotify")
     public ResponseEntity<?> authenticateWithSpotify(@RequestParam("code") String code) {
-        return ResponseEntity.ok(spotifyAuthService.exchangeCodeForTokens(code));
+        Map<String, Object> tokens = spotifyAuthService.exchangeCodeForTokens(code);
+
+        String accessToken = (String) tokens.get("access_token");
+        String refreshToken = (String) tokens.get("refresh_token");
+        Integer expiresIn = (Integer) tokens.get("expires_in");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        HttpEntity<?> request = new HttpEntity<>(headers);
+        RestTemplate restTemplate = new RestTemplate();
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                "https://api.spotify.com/v1/me",
+                HttpMethod.GET,
+                request,
+                Map.class
+        );
+
+        String userId = (String) response.getBody().get("id");
+
+        spotifyTokenService.saveTokens(userId, accessToken, refreshToken, expiresIn);
+
+        return ResponseEntity.ok(Map.of("message", "Authenticated successfully", "userId", userId));
     }
 
     @PostMapping("/auth/spotify/refresh")

--- a/src/main/java/com/spotifyapp/backend/controller/LoginController.java
+++ b/src/main/java/com/spotifyapp/backend/controller/LoginController.java
@@ -24,7 +24,7 @@ public class LoginController {
         String scope = "user-top-read";
         String authorizeURL = "https://accounts.spotify.com/authorize?" +
                 "response_type=code" +
-                "&client_id" + clientId +
+                "&client_id=" + clientId +
                 "&scope=" + URLEncoder.encode(scope, StandardCharsets.UTF_8) +
                 "&redirect_uri=" + URLEncoder.encode(redirectUri, StandardCharsets.UTF_8);
 

--- a/src/main/java/com/spotifyapp/backend/model/SpotifyToken.java
+++ b/src/main/java/com/spotifyapp/backend/model/SpotifyToken.java
@@ -1,0 +1,24 @@
+package com.spotifyapp.backend.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SpotifyToken {
+    @Id
+    private String userId;
+
+    private String accessToken;
+    private String refreshToken;
+    private Instant expiresAt;
+}

--- a/src/main/java/com/spotifyapp/backend/repository/SpotifyTokenRepository.java
+++ b/src/main/java/com/spotifyapp/backend/repository/SpotifyTokenRepository.java
@@ -1,0 +1,7 @@
+package com.spotifyapp.backend.repository;
+
+import com.spotifyapp.backend.model.SpotifyToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpotifyTokenRepository extends JpaRepository<SpotifyToken, String> {
+}

--- a/src/main/java/com/spotifyapp/backend/service/SpotifyTokenService.java
+++ b/src/main/java/com/spotifyapp/backend/service/SpotifyTokenService.java
@@ -1,0 +1,54 @@
+package com.spotifyapp.backend.service;
+
+import com.spotifyapp.backend.model.SpotifyToken;
+import com.spotifyapp.backend.repository.SpotifyTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class SpotifyTokenService {
+
+    private final SpotifyTokenRepository repository;
+    private final SpotifyAuthService authService;
+
+
+    public SpotifyToken getValidAccessToken(String userId) {
+        SpotifyToken token = repository.findById(userId).orElseThrow();
+
+        if (token.getExpiresAt().isBefore(Instant.now().plusSeconds(60))) {
+            token = refreshAccessToken(token);
+            repository.save(token);
+        }
+
+        return token;
+    }
+
+    public SpotifyToken refreshAccessToken(SpotifyToken oldToken) {
+        Map<String, Object> response = authService.refreshAccessToken(oldToken.getRefreshToken());
+
+        String newAccessToken = (String) response.get("access_token");
+        Integer expiresIn = (Integer) response.get("expires_in");
+
+        oldToken.setAccessToken(newAccessToken);
+        oldToken.setExpiresAt(Instant.now().plusSeconds(expiresIn));
+
+        return oldToken;
+    }
+
+    public void saveTokens(String userId, String accessToken, String refreshToken, long expiresIn) {
+        SpotifyToken token = SpotifyToken.builder()
+                .userId(userId)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .expiresAt(Instant.now().plusSeconds(expiresIn))
+                .build();
+
+        repository.save(token);
+    }
+
+}


### PR DESCRIPTION
This PR implements:

- Core logic for authenticating users with spotify.
- Exchanges the code for access and refresh tokens
- Stores tokens and expiration info using in-memory H2 database.
- Validated with Postman and confirmed persistence in H2 console.